### PR TITLE
Update Compat Entry for CEnum to `^0.5.0`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,7 @@ liblsl_jll = "b37880e1-55fa-5503-9f1a-f1223ce0b53e"
 CEnum = "^0.2.0"
 LightXML = "^0.9.0"
 julia = "^1.3.0"
-liblsl_jll = "^1.13.0"
+liblsl_jll = "1.16.2"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,7 @@ LightXML = "9c8b4983-aa76-5018-a973-4c85ecc9e179"
 liblsl_jll = "b37880e1-55fa-5503-9f1a-f1223ce0b53e"
 
 [compat]
-CEnum = "^0.2.0"
+CEnum = "^0.5.0"
 LightXML = "^0.9.0"
 julia = "^1.3.0"
 liblsl_jll = "1.16.2"


### PR DESCRIPTION
I ran into issues with LSL compatibility on Julia 1.12 when working with GLMakie, when using LSL with the current compat entry for CEnum the GLMakie version can not compiled as the version of CEnum is too old.

After updating the CEnum compat entry, the tests come up green - and in usage with a Muse Headset I have yet to see any regressions.
